### PR TITLE
SessionEventArgs: A typo in an exception + wrong decompression method for zlib when reading the request headers.

### DIFF
--- a/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
+++ b/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
@@ -265,7 +265,7 @@ namespace Titanium.Web.Proxy.EventArguments
 
         public void SetRequestBodyString(string body)
         {
-            if (RequestLocked) throw new Exception("Youcannot call this function after request is made to server.");
+            if (RequestLocked) throw new Exception("You cannot call this function after request is made to server.");
 
             if (!RequestBodyRead)
             {

--- a/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
+++ b/Titanium.Web.Proxy/EventArguments/SessionEventArgs.cs
@@ -168,7 +168,7 @@ namespace Titanium.Web.Proxy.EventArguments
                                     RequestBody = CompressionHelper.DecompressDeflate(requestBodyStream);
                                     break;
                                 case "zlib":
-                                    RequestBody = CompressionHelper.DecompressGzip(requestBodyStream);
+                                    RequestBody = CompressionHelper.DecompressZlib(requestBodyStream);
                                     break;
                                 default:
                                     RequestBody = requestBodyStream.ToArray();


### PR DESCRIPTION
I fixed two small bugs in SessionEventArgs.