### PR TITLE
Locate makecert.exe next to the assembly

### DIFF
--- a/Titanium.Web.Proxy/Helpers/CertificateManager.cs
+++ b/Titanium.Web.Proxy/Helpers/CertificateManager.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using System.Reflection;
 
 namespace Titanium.Web.Proxy.Helpers
 {
@@ -112,14 +113,16 @@ namespace Titanium.Web.Proxy.Helpers
         {
             using (var process = new Process())
             {
-                if (!File.Exists("makecert.exe"))
+                string file = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "makecert.exe");
+
+                if (!File.Exists(file))
                     throw new Exception("Unable to locate 'makecert.exe'.");
 
                 process.StartInfo.Verb = "runas";
                 process.StartInfo.Arguments = args != null ? args[0] : string.Empty;
                 process.StartInfo.CreateNoWindow = true;
                 process.StartInfo.UseShellExecute = false;
-                process.StartInfo.FileName = "makecert.exe";
+                process.StartInfo.FileName = file;
 
                 process.Start();
                 process.WaitForExit();


### PR DESCRIPTION
It was located from the current directory. This can result in a
FileNotFoundException when an application that uses Titanium-Web-Proxy
is launched from another path, the root certificate is not registered
and capturing is started . E.g.  c:\> test\test.exe